### PR TITLE
Release 0.10.0

### DIFF
--- a/src/Models/NomadFileData.cs
+++ b/src/Models/NomadFileData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace OwlCore.Nomad.Storage.Models;
+﻿namespace OwlCore.Nomad.Storage.Models;
 
 /// <summary>
 /// Represents the state of a file stored in Nomad.

--- a/src/Models/NomadFolderData.cs
+++ b/src/Models/NomadFolderData.cs
@@ -6,22 +6,22 @@ namespace OwlCore.Nomad.Storage.Models;
 /// <summary>
 /// Represents the state of a folder stored in Nomad.
 /// </summary>
-public record NomadFolderData<TContentPointer> : NomadStorableData, ISources<TContentPointer>
-    where TContentPointer : class
+public record NomadFolderData<TImmutablePointer, TMutablePointer> : NomadStorableData, ISources<TMutablePointer>
+    where TImmutablePointer : class
 {
     /// <summary>
     /// Data that represents the files in this folder
     /// </summary>
-    public List<NomadFileData<TContentPointer>> Files { get; set; } = new();
+    public List<NomadFileData<TImmutablePointer>> Files { get; set; } = new();
     
     /// <summary>
     /// Data that represents the folders in this folder.
     /// </summary>
-    public List<NomadFolderData<TContentPointer>> Folders { get; set; } = new();
+    public List<NomadFolderData<TImmutablePointer, TMutablePointer>> Folders { get; set; } = new();
 
     /// <inheritdoc />
     // ? do this here or upstream?
     // are we publishing this model or transforming it to mfs and a single cid for roaming?
     // roaming needs sources, but folders aren't json 
-    public ICollection<TContentPointer> Sources { get; init; } = new List<TContentPointer>();
+    public ICollection<TMutablePointer> Sources { get; init; } = new List<TMutablePointer>();
 }

--- a/src/Models/NomadStorableData.cs
+++ b/src/Models/NomadStorableData.cs
@@ -3,7 +3,7 @@
 namespace OwlCore.Nomad.Storage.Models;
 
 /// <summary>
-/// A common base record for <see cref="NomadFolderData{TContentPointer}"/> and <see cref="NomadFileData{TContentPointer}"/>.
+/// A common base record for <see cref="NomadFolderData{TImmutablePointer, TMutablePointer}"/> and <see cref="NomadFileData{TContentPointer}"/>.
 /// </summary>
 public abstract record NomadStorableData
 {

--- a/src/NomadFile.cs
+++ b/src/NomadFile.cs
@@ -9,12 +9,12 @@ using System.Threading.Tasks;
 namespace OwlCore.Nomad.Storage;
 
 /// <summary>
-/// A virtual file constructed by advancing an <see cref="IEventStreamHandler{TContentPointer, TEventStreamSource, TEventStreamEntry}.EventStreamPosition"/> using multiple <see cref="ISources{T}.Sources"/>.
+/// A virtual file constructed by advancing an <see cref="IEventStreamHandler{TImmutablePointer, TMutablePointer, TEventStreamSource, TEventStreamEntry}.EventStreamPosition"/> using multiple <see cref="ISources{T}.Sources"/>.
 /// </summary>
-public abstract class NomadFile<TContentPointer, TEventStreamSource, TEventStreamEntry> : IFile, IChildFile, IEventStreamHandler<TContentPointer, TEventStreamSource, TEventStreamEntry>, IDelegable<NomadFileData<TContentPointer>>
-    where TEventStreamSource : EventStream<TContentPointer>
-    where TEventStreamEntry : EventStreamEntry<TContentPointer>
-    where TContentPointer : class
+public abstract class NomadFile<TImmutablePointer, TMutablePointer, TEventStreamSource, TEventStreamEntry> : IFile, IChildFile, IEventStreamHandler<TImmutablePointer, TMutablePointer, TEventStreamSource, TEventStreamEntry>, IDelegable<NomadFileData<TImmutablePointer>>
+    where TEventStreamSource : EventStream<TImmutablePointer>
+    where TEventStreamEntry : EventStreamEntry<TImmutablePointer>
+    where TImmutablePointer : class
 {
     /// <inheritdoc cref="IStorable.Id" />
     public string Id => Inner.StorableItemId;
@@ -31,13 +31,13 @@ public abstract class NomadFile<TContentPointer, TEventStreamSource, TEventStrea
     public required IFolder? Parent { get; init; }
     
     /// <inheritdoc />
-    public required NomadFileData<TContentPointer> Inner { get; set; }
+    public required NomadFileData<TImmutablePointer> Inner { get; set; }
 
     /// <inheritdoc />
     public virtual Task ResetEventStreamPositionAsync(CancellationToken cancellationToken)
     {
         EventStreamPosition = null;
-        Inner = new NomadFileData<TContentPointer> {  StorableItemName = Name, StorableItemId = Id, ContentId = null, };
+        Inner = new NomadFileData<TImmutablePointer> {  StorableItemName = Name, StorableItemId = Id, ContentId = null, };
         return Task.CompletedTask;
     }
 
@@ -48,7 +48,7 @@ public abstract class NomadFile<TContentPointer, TEventStreamSource, TEventStrea
     public TEventStreamEntry? EventStreamPosition { get; set; }
 
     /// <inheritdoc />
-    public required ICollection<TContentPointer> Sources { get; init; }
+    public required ICollection<TMutablePointer> Sources { get; init; }
 
     /// <inheritdoc />
     public abstract Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default);

--- a/src/OwlCore.Nomad.Storage.csproj
+++ b/src/OwlCore.Nomad.Storage.csproj
@@ -16,7 +16,7 @@
 		<Author>Arlo Godfrey</Author>
 		<Version>0.10.0</Version>
 		<Product>OwlCore</Product>
-		<Description></Description>
+		<Description>A virtual storage implementation powered by event stream sourcing.</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Storage</PackageProjectUrl>

--- a/src/OwlCore.Nomad.Storage.csproj
+++ b/src/OwlCore.Nomad.Storage.csproj
@@ -24,6 +24,10 @@
 --- 0.10.0 ---
 [Breaking]
 The first generic param TContentPointer on NomadFolder, NomadFile and NomadFolderData have been expanded to TImmutablePointer, TMutablePointer and all implementation code has been updated accordingly.
+Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0.
+NomadFile generics are now NomadFile{TImmutablePointer, TMutablePointer, TEventStream, TEventStreamEntry} instead of NomadFile{TContentPointer, TEventStream, TEventStreamEntry}.
+NomadFolder generics are now NomadFolder{TImmutablePointer, TMutablePointer, TEventStream, TEventStreamEntry} instead of NomadFolder{TContentPointer, TEventStream, TEventStreamEntry}.
+NomadFolderData generics are now NomadFolderData{TImmutablePointer, TMutablePointer} instead of NomadFolderData{TContentPointer}.
 
 --- 0.9.1 ---
 [Improvements]
@@ -134,11 +138,12 @@ Initial release of OwlCore.Nomad.Storage.
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="OwlCore.Extensions" Version="0.9.1" />
-		<PackageReference Include="OwlCore.Storage" Version="0.12.0" />
+		<PackageReference Include="OwlCore.Storage" Version="0.12.2" />
+		<PackageReference Include="OwlCore.Nomad" Version="0.10.1" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -151,9 +156,5 @@ Initial release of OwlCore.Nomad.Storage.
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\ocnomad\src\OwlCore.Nomad.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/OwlCore.Nomad.Storage.csproj
+++ b/src/OwlCore.Nomad.Storage.csproj
@@ -14,13 +14,17 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.9.1</Version>
+		<Version>0.10.0</Version>
 		<Product>OwlCore</Product>
 		<Description></Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Storage</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.10.0 ---
+[Breaking]
+The first generic param TContentPointer on NomadFolder, NomadFile and NomadFolderData have been expanded to TImmutablePointer, TMutablePointer and all implementation code has been updated accordingly.
+
 --- 0.9.1 ---
 [Improvements]
 Refactor methods in NomadFolder to be virtual for extensibility.
@@ -134,7 +138,6 @@ Initial release of OwlCore.Nomad.Storage.
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="OwlCore.Extensions" Version="0.9.1" />
-		<PackageReference Include="OwlCore.Nomad" Version="0.9.0" />
 		<PackageReference Include="OwlCore.Storage" Version="0.12.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
@@ -148,5 +151,9 @@ Initial release of OwlCore.Nomad.Storage.
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\ocnomad\src\OwlCore.Nomad.csproj" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
[Breaking]
-  The first generic param TContentPointer on NomadFolder, NomadFile and NomadFolderData have been expanded to TImmutablePointer, TMutablePointer and all implementation code has been updated accordingly.
- Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0.
- NomadFile generics are now NomadFile{TImmutablePointer, TMutablePointer, TEventStream, TEventStreamEntry} instead of NomadFile{TContentPointer, TEventStream, TEventStreamEntry}.
- NomadFolder generics are now NomadFolder{TImmutablePointer, TMutablePointer, TEventStream, TEventStreamEntry} instead of NomadFolder{TContentPointer, TEventStream, TEventStreamEntry}.
- NomadFolderData generics are now NomadFolderData{TImmutablePointer, TMutablePointer} instead of NomadFolderData{TContentPointer}.
